### PR TITLE
Change access_type by test in whitelist entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Response:
         "_id":"5feb49d2692ccd5dd7df0fzj",
         "game_tag":"rafa4k",
         "twitch_user":"rafa4k",
-        "access_type":"Access by subscription",
+        "note":"Access by subscription",
         "access_expiry_date":"2021-03-29T14:22:58.677Z",
         "uuid":"a39285c9-3044-3ab9-b22a-399624e81601",
         "created_at":"2020-12-29T15:22:59.054Z",
@@ -71,7 +71,7 @@ Response:
         "_id":"49su49d2692ccd5dd7df3891",
         "game_tag":"AvocadoMaster",
         "twitch_user":"aldea_jete",
-        "access_type":"Access by subscription",
+        "note":"Access by subscription",
         "access_expiry_date":"2021-03-30T14:22:58.677Z",
         "uuid":"32158fc9-3044-3ab9-b22a-399624e81179",
         "created_at":"2020-12-29T15:22:59.054Z",
@@ -96,7 +96,7 @@ Response:
     "_id":"49su49d2692ccd5dd7df3891",
     "game_tag":"AvocadoMaster",
     "twitch_user":"aldea_jete",
-    "access_type":"Access by subscription",
+    "note":"Access by subscription",
     "access_expiry_date":"2021-03-30T14:22:58.677Z",
     "uuid":"32158fc9-3044-3ab9-b22a-399624e81179",
     "created_at":"2020-12-29T15:22:59.054Z",
@@ -113,7 +113,7 @@ Request:
 
 ``` bash
 curl -i -H 'Content-Type: application/json' http://localhost:4000/api/whitelist/ \
--d '{"game_tag":"Bobby", "twitch_user":"Tables", "access_type":"Fortnight", "access_time":"15d"}'
+-d '{"game_tag":"Bobby", "twitch_user":"Tables", "note":"Fortnight", "access_time":"15d"}'
 ```
 
 
@@ -151,7 +151,7 @@ Request:
 
 ``` bash
 curl -X PUT -i -H 'Content-Type: application/json' http://localhost:4000/api/whitelist/5feb49d2609ccd5dd7df0f25 \
--d '{"_id":"5feb49d2609ccd5dd7df0f25", "access_type": "Access by subscription", "access_time": "1M" }'
+-d '{"_id":"5feb49d2609ccd5dd7df0f25", "note": "Access by subscription", "access_time": "1M" }'
 ```
 
 Response:

--- a/src/models/schemas/WhitelistSchema.ts
+++ b/src/models/schemas/WhitelistSchema.ts
@@ -4,8 +4,7 @@ import { Schema } from 'mongoose'
 const WhitelistSchema = new Schema({
   game_tag: { type: String, unique: true },
   twitch_user: { type: String, unique: true },
-  access_type: String,
-  premium_account: Boolean,
+  note: String,
   uuid: String,
   access_expiry_date: Date,
 }, {

--- a/src/types/UserDoc.ts
+++ b/src/types/UserDoc.ts
@@ -3,8 +3,7 @@ import mongoose from 'mongoose'
 export interface UserDoc extends mongoose.Document {
   game_tag: { type: string, unique: true },
   twitch_user: { type: string, unique: true },
-  access_type: string,
-  premium_account: boolean,
+  note: string,
   uuid: string,
   access_expiry_date: Date,
 }


### PR DESCRIPTION
This PRs removes the `access_type` field from the whitelist entry body since is too specific. Instead, the more generic `note` field has been added.

``` JSON
{
    "_id": "5ff5aa258d6448432674ed4",
    "game_tag": "Jesus",
    "twitch_user": "Jesusgn90",
    "note": "Tryhard",
    "access_expiry_date": "2021-01-06T12:16:40.886Z",
    "uuid": "95318971-7d22-3da3-b018-f8307cc4b5f7",
    "created_at": "2021-01-06T12:16:38.273Z",
    "updated_at": "2021-01-06T12:27:40.603Z",
    "__v": 0
}
``` 

The `premium_account` field has also been removed because it had no purpose.