### PR TITLE
Allow to link a discord user with a whitelist entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Response:
     {
         "_id":"5feb49d2692ccd5dd7df0fzj",
         "game_tag":"rafa4k",
-        "twitch_user":"rafa4k",
+        "discord_user":"rafa4k#87412",
         "note":"Access by subscription",
         "access_expiry_date":"2021-03-29T14:22:58.677Z",
         "uuid":"a39285c9-3044-3ab9-b22a-399624e81601",
@@ -113,7 +113,7 @@ Request:
 
 ``` bash
 curl -i -H 'Content-Type: application/json' http://localhost:4000/api/whitelist/ \
--d '{"game_tag":"Bobby", "twitch_user":"Tables", "note":"Fortnight", "access_time":"15d"}'
+-d '{"game_tag":"Bobby", "twitch_user":"Tables", "discord_user":"Tables#4238", "note":"Fortnight", "access_time":"15d"}'
 ```
 
 

--- a/src/models/schemas/WhitelistSchema.ts
+++ b/src/models/schemas/WhitelistSchema.ts
@@ -4,6 +4,7 @@ import { Schema } from 'mongoose'
 const WhitelistSchema = new Schema({
   game_tag: { type: String, trim: true, unique: true, sparse: true },
   twitch_user: { type: String, trim: true, unique: true, sparse: true },
+  discord_user: { type: String, trim: true, unique: true, sparse: true },
   note: { type: String, trim: true},
   uuid: String,
   access_expiry_date: Date,

--- a/src/types/UserDoc.ts
+++ b/src/types/UserDoc.ts
@@ -3,6 +3,7 @@ import mongoose from 'mongoose'
 export interface UserDoc extends mongoose.Document {
   game_tag: { type: string, unique: true, sparse: true },
   twitch_user: { type: string, unique: true, sparse: true },
+  discord_user: { type: string, unique: true, sparse: true },
   note: { type: string, trim: true},
   uuid: string,
   access_expiry_date: Date,


### PR DESCRIPTION
This PR adds the possibility of linking a discord user with a whitelist entry. To do this, you just have to add the `discord_user` field to the request body. This value is optional but cannot be duplicated.